### PR TITLE
Revised README.md to be more sensible

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,14 @@
 
 ## Requirements
 
-Command:Version
-docker-compose:>=1.24.0
-pip:>=19.1.1 
+This software needs docker-compose version 1.24.0 at least.
 
 ## Setting it up
 
 In an appropriate directory:
 * git clone git@github.com:silinternational/handcarry-api.git
-* cd handcarry-api
-* docker-compose up -d
+* cd handcarry-api/application
+* make
 
 ## Installation Troubleshooting
 
@@ -20,7 +18,3 @@ may have earlier versions of these installed.
 
 Make sure to uninstall docker-compose packages, and then following the
 instructions here: https://docs.docker.com/compose/install/
-
-Python 2.7 is End of Life January 2020, make sure you are using
-python-pip3 and then upgrade it accordingly.
-


### PR DESCRIPTION
Formatting of requirements section was ugly, and pip is no longer needed as of 1.24.0 it seems.